### PR TITLE
Fixed bowser typing

### DIFF
--- a/deps/csp/lib/bowser/src/bowser.js
+++ b/deps/csp/lib/bowser/src/bowser.js
@@ -1,3 +1,4 @@
+/// <reference types="../index.d.ts" />
 /*!
  * Bowser - a browser detector
  * https://github.com/lancedikson/bowser


### PR DESCRIPTION
`deno bundle mod.ts` had this error:
```
Bundling file:///home/alicegg/Personal/contrib/snelm/mod.ts
error: TS2694 [ERROR]: Namespace '"file:///home/alicegg/Personal/contrib/snelm/deps/csp/lib/bowser/src/bowser"' has no exported member 'Parser'.
  [browserName: string]: (browser: Bowser.Parser.Parser, options: CspOptions) => string[];
                                          ~~~~~~
    at file:///home/alicegg/Personal/contrib/snelm/deps/csp/lib/get-header-keys-for-browser.ts:10:43

TS2694 [ERROR]: Namespace '"file:///home/alicegg/Personal/contrib/snelm/deps/csp/lib/bowser/src/bowser"' has no exported member 'Parser'.
export default function getHeaderKeysForBrowser (browser: Bowser.Parser.Parser | undefined, options: CspOptions) {
                                                                 ~~~~~~
    at file:///home/alicegg/Personal/contrib/snelm/deps/csp/lib/get-header-keys-for-browser.ts:101:66

TS2694 [ERROR]: Namespace '"file:///home/alicegg/Personal/contrib/snelm/deps/csp/lib/bowser/src/bowser"' has no exported member 'Parser'.
  browser: Bowser.Parser.Parser | undefined,
                  ~~~~~~
    at file:///home/alicegg/Personal/contrib/snelm/deps/csp/lib/transform-directives-for-browser.ts:47:19

Found 3 errors.
```

This PR should fix it by properly indicating to deno the typing file in the bowser dep.