### PR TITLE
Update Oak example in README to return middleware promise

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ const snelm = new Snelm("oak");
 app.use((ctx, next) => {
     ctx.response = snelm.snelm(ctx.request, ctx.response);
 
-    next();
+    return next();
 });
 
 app.use((ctx) => {


### PR DESCRIPTION
Small thing, but it makes a difference.

For example, I had a middleware that was setting up a web socket after this. Because the Snelm middleware wasn't awaiting or returning the chain of middleware, Oak was immediately doing cleanup on the request and closing it prior to the connection upgrade completing. It took me approximately forever to figure this out